### PR TITLE
Handle serialized postmeta values

### DIFF
--- a/wp-post-branches.php
+++ b/wp-post-branches.php
@@ -12,7 +12,7 @@ Text Domain: wp_post_branches
 
 if ( ! defined( 'WPBS_DOMAIN' ) )
 	define( 'WPBS_DOMAIN', 'wp_post_branches' );
-	
+
 if ( ! defined( 'WPBS_PLUGIN_URL' ) )
 	define( 'WPBS_PLUGIN_URL', plugins_url() . '/' . dirname( plugin_basename( __FILE__ ) ));
 
@@ -60,12 +60,12 @@ function wpbs_pre_post_update( $id ) {
 
 			$values = get_post_custom_values($key, $id );
 			foreach ( $values as $value ) {
-				add_post_meta( $draft_id, $key, $value );
+				add_post_meta( $draft_id, $key, maybe_unserialize($value) );
 			}
 		}
 
 		//attachment
-		$args = array( 'post_type' => 'attachment', 'numberposts' => -1, 'post_status' => null, 'post_parent' => $id ); 
+		$args = array( 'post_type' => 'attachment', 'numberposts' => -1, 'post_status' => null, 'post_parent' => $id );
 		$attachments = get_posts( $args );
 		if ($attachments) {
 			foreach ( $attachments as $attachment ) {
@@ -101,7 +101,7 @@ function wpbs_pre_post_update( $id ) {
 				foreach ( (array) $keys as $key ) {
 					$value = get_post_meta( $attachment->ID, $key, true );
 
-				add_post_meta( $attachment_newid, $key, $value );
+				add_post_meta( $attachment_newid, $key, maybe_unserialize($value) );
 				}
 			}
 		}
@@ -119,7 +119,7 @@ function wpbs_pre_post_update( $id ) {
 		}
 
 		add_post_meta($draft_id, '_wpbs_pre_post_id', $id);
-		
+
 		if ( ! defined( 'DOING_CRON' ) || ! DOING_CRON ) {
 			wp_safe_redirect( admin_url( 'post.php?post=' . $draft_id . '&action=edit' ) );
 			exit;
@@ -192,13 +192,13 @@ function wpbs_save_post( $id, $post ) {
 
 			if ( preg_match( '/_wp_old_slug/', $key ) )
 				continue;
-				
+
 			$key = apply_filters( 'wpbs_draft_to_publish_postmeta_filter', $key );
 
 			delete_post_meta( $org_id, $key );
 			$values = get_post_custom_values($key, $id );
 			foreach ( $values as $value ) {
-				add_post_meta( $org_id, $key, $value );
+				add_post_meta( $org_id, $key, maybe_unserialize($value) );
 			}
 		}
 
@@ -212,7 +212,7 @@ function wpbs_save_post( $id, $post ) {
 //			}
 //		}
 
-		$args = array( 'post_type' => 'attachment', 'numberposts' => -1, 'post_status' => null, 'post_parent' => $id ); 
+		$args = array( 'post_type' => 'attachment', 'numberposts' => -1, 'post_status' => null, 'post_parent' => $id );
 		$attachments = get_posts( $args );
 		if ($attachments) {
 			foreach ( $attachments as $attachment ) {
@@ -249,7 +249,7 @@ function wpbs_save_post( $id, $post ) {
 					$value = get_post_meta( $attachment->ID, $key, true );
 
 					delete_post_meta( $org_id, $key );
-					add_post_meta( $org_id, $key, $value );
+					add_post_meta( $org_id, $key, maybe_unserialize($value) );
 				}
 			}
 		}


### PR DESCRIPTION
**■ 目的**

[ACF](https://www.advancedcustomfields.com/)利用時など、postmeta（カスタムフィールド）にシリアライズされたデータが入っている場合でも、問題なくブランチを作成／公開できるようにする。

**■ 背景**

現状では、postmeta にシリアライズされたデータが入っていると、ブランチの作成時／公開時にそのデータが壊れてしまい、以下のような問題が発生してました。

- ブランチを作成時、元記事の一部のカスタムフィールドの内容が引き継がれない。
- ブランチを公開時、下書きのときにあった一部のカスタムフィールドの内容が失われてしまう。

たとえば以下のようなメタデータを持つ元記事からブランチを作成すると、

|meta_id|post_id|meta_key|meta_value
|---|---|---|---
|115515|2775|related-place|`a:1:{i:0;s:3:299";}"`

ブランチ側のメタデータは以下のように変わって（二重にシリアライズされて）しまっていました。

|meta_id|post_id|meta_key|meta_value
|---|---|---|---
|116431|5169|related-place|`s:20:a:1:{i:0;s:3:"299";}";"`

cf.
- [ブランチを作成するとACF\(Advanced Custom Fields\)で作成した関連フィールドで選んだコンテンツがなくなってしまう。 \| WordPress\.org](https://wordpress.org/support/topic/%e3%83%96%e3%83%a9%e3%83%b3%e3%83%81%e3%82%92%e4%bd%9c%e6%88%90%e3%81%99%e3%82%8b%e3%81%a8acfadvanced-custom-fields%e3%81%a7%e4%bd%9c%e6%88%90%e3%81%97%e3%81%9f%e9%96%a2%e9%80%a3%e3%83%95%e3%82%a3/)
- [WordPress - WordPressのプラグイン「WP Post Branches」で、ブランチを作ると、チェックボックスが外れている｜teratail](https://teratail.com/questions/181610)

**■ 方針**

`add_post_meta()` 関数に渡す meta_value をあらかじめ `maybe_unserialize()` して、データが二重にシリアライズされてしまうことを防ぐ。


**■ 技術メモ**

- [Function Reference/add post meta « WordPress Codex](https://codex.wordpress.org/Function_Reference/add_post_meta)
- [add_metadata() | Function | WordPress Developer Resources](https://developer.wordpress.org/reference/functions/add_metadata/)
- [Function Reference/maybe serialize « WordPress Codex](https://codex.wordpress.org/Function_Reference/maybe_serialize)
- [Function Reference/maybe unserialize « WordPress Codex](https://codex.wordpress.org/Function_Reference/maybe_unserialize)

根源的には上記の `maybe_serialize()` のドキュメントにあるように

> Confusingly, strings that contain already serialized values are serialized again, resulting in a nested serialization. Other strings are unmodified.

という挙動に起因している。

---

どうぞよろしくお願いいたします :bow: